### PR TITLE
Update actions/checkout to v3 in pythonapp.yml

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Reason:

```
The following actions uses node12 which is deprecated
and will be forced to run on node16: actions/checkout@v2.
```